### PR TITLE
create modules: authorization changed to cancan

### DIFF
--- a/source/create_modules.textile
+++ b/source/create_modules.textile
@@ -44,7 +44,7 @@ class Ability
   include CanCan::Ability
 
   def initialize(user)
-    if user.is_admin?
+    if !user.blank? && user.is_admin?
       can :manage, YourResource
       can :manage, :admin_your_resource
     end


### PR DESCRIPTION
Just updated the developer version of a 2.7 alchemy project with custom modules to 3.0 and stumbled upon it :-)
