### PR TITLE
Add information to readme on how to preview local guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@ Please check out the other branches for guides for the latest stable or older ve
 
 The guides are created with the [guides](https://github.com/wycats/guides) gem and are written in [textile](http://redcloth.org/textile) markup.
 
+## Previewing the guides locally
+
+Run `bundle install` to install [guides](https://github.com/wycats/guides).
+
+To run a local guides server, run `guides preview`. The server will be available at [0.0.0.0:9292](http://0.0.0.0:9292).
+
 ## Contributing
 
 1. Fork it


### PR DESCRIPTION
It's already documented in the [guides readme](https://github.com/wycats/guides/blob/master/README.md), but this way eventual contributers can get started a bit faster without having to look it up in the other readme.
