### PR TITLE
Guides for Alchemy v2.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 The Alchemy CMS Guidelines
 ==========================
 
-These Alchemy guides cover Alchemy CMS v.2.7
+These Alchemy guides cover Alchemy CMS v.2.9
 
 The guides are created with the [guides](https://github.com/wycats/guides) gem and are written in [textile](http://redcloth.org/textile) markup.
 

--- a/guides.yml
+++ b/guides.yml
@@ -1,6 +1,6 @@
 title: Alchemy CMS Guides
 description: "Alchemy CMS is an awesome Content Management System with a flexible content storing architecture."
-version: "2.7.0"
+version: "2.9.0"
 
 authors:
   Core Team:
@@ -50,7 +50,6 @@ index:
     - title: Essences
       url: essences
       text: What are essences and how do they work.
-      construction: true
 
   3.) How to work with Alchemy:
     - title: The Alchemy approach
@@ -80,14 +79,12 @@ index:
     - title: Upgrading Alchemy
       url: upgrading
       text: Learn how to upgrade Alchemy to newest version
-      construction: true
 
   4.) Customization guides:
 
     - title: Customizing the Richtext Editor
       url: customize_tinymce
       text: Learn how to customize the TinyMCE richtext editor.
-
 
   5.) Advanced topics:
 
@@ -98,6 +95,11 @@ index:
     - title: Create Modules
       url: create_modules
       text: How to create custom modules.
+
+    - title: Custom Authentication
+      url: custom_authentication
+      text: How to add your own custom authentication.
+
 
   6.) Deployment:
     - title: Deploying on RailsHoster

--- a/source/custom_authentication.textile
+++ b/source/custom_authentication.textile
@@ -1,0 +1,106 @@
+h2. Custom Authentication
+
+Since version 2.9 Alchemy has removed it's build in authentication into a separate gem, called <code>alchemy-devise</code>. Now, that this is not in the core anymore it gives you the possibility to add your own custom authentification.
+
+You only have to tell Alchemy about your user class.
+
+endprologue.
+
+h3. Activating your model
+
+Alchemy has some defaults for user model name and login logout path names:
+
+h4. Defaults
+
+* <code>Alchemy.user_class_name</code> defaults to <code>'User'</code>
+* <code>Alchemy.login_path</code> defaults to <code>'/login'</code>
+* <code>Alchemy.logout_path</code> defaults to <code>'/logout'</code>
+
+Anyway, you can tell Alchemy about your authentication model configuration.
+
+h5. Example
+
+<ruby>
+# config/initializers/alchemy.rb
+Alchemy.user_class_name = 'Admin'
+Alchemy.login_path = '/auth/login'
+Alchemy.logout_path = '/auth/logout'
+</ruby>
+
+h3. Mandatory methods
+
+h4. alchemy_roles
+
+In your app's user class, the only method that Alchemy CMS needs in order to run is <code>alchemy_roles</code>.
+
+This method has to return an array of strings, containing at least one of these roles:
+
+* member
+* author
+* editor
+* admin
+
+h5. Example
+
+<ruby>
+def alchemy_roles
+  if admin?
+    %w(admin)
+  end
+end
+</ruby>
+
+h3. Optional methods
+
+But, there are still few other attributes that are good to have in your user class which are:
+
+h4. name
+
+This would be used to say <code>"Welcome back #{@user.name}"</code> and is used in the "logged in as" note on the top right corner of the admin interface.
+
+h5. Example
+
+<ruby>
+def name
+  # If you don't have a name, you could use the user's email
+  read_attribute(:email)
+end
+</ruby>
+
+h4. language
+
+A locale String to set the users preferred translation of the Alchemy GUI.
+
+h5. Example
+
+<ruby>
+# Always use dutch as translation
+def language
+  'nl'
+end
+</ruby>
+
+h4. Userstamp columns
+
+Alchemy stores updater and creator ids, if the columns are present.
+If you want to track which user updated another user, you can add
+
+`creator_id` and `updater_id` as integer columns to you users table.
+
+h4. Tagging
+
+If you want to tag your users you can add the <code>acts_as_taggable</code> and <code>acts_as_tagger</code> class methods.
+
+h5. Example
+
+<ruby>
+class User < ActiveRecord::Base
+  acts_as_taggable
+  acts_as_tagger
+  ...
+end
+</ruby>
+
+NOTE: You also need to add a <code>cached_tag_list</code> text column to your users table.
+
+&nbsp;

--- a/source/getting_started.textile
+++ b/source/getting_started.textile
@@ -9,7 +9,6 @@ endprologue.
 
 
 
-
 h3. Guide Assumptions
 
 This guide is designed for beginners who want to get started with Alchemy CMS from scratch. It does not assume that you have any prior experience with Alchemy CMS. However, to get the most out of it, you need to have some prerequisites installed:
@@ -67,7 +66,7 @@ If you already have an existing Rails application, you can require the Alchemy C
 Just add this line to your Gemfile.
 
 <pre>
-gem 'alchemy_cms', '~> 2.7.1'
+gem 'alchemy_cms', :github => 'magiclabs/alchemy_cms', :branch => '2.9-stable'
 </pre>
 
 Since Alchemy CMS is a mountable engine, you need to define the mountpoint in your <code>config/routes.rb</code> file.

--- a/source/upgrading.textile
+++ b/source/upgrading.textile
@@ -1,492 +1,112 @@
 h2. Upgrading Alchemy CMS
 
-This guide describes how to upgrade Alchemy CMS from an older Alchemy version.
+This guide describes how to upgrade Alchemy CMS to version 2.9 and assumes that your current Alchemy version is v2.7 .
 
-* Update to latest version
-* Upgrade from prior version
+You should always upgrade from the next prior Alchemy release (based on your current version).
+
+In contrast to v2.7 Alchemy 2.9 offers the opportunity to use a <strong>custom user model</strong> instead of the <strong>default user model</strong> (this is the mayor difference).
 
 endprologue.
 
-Since Alchemy is active maintained and continuously enhanced, there will be need to upgrade in order to benefit from
-new feature and fixed issues.
-<p><strong>In general, no content will be touched or removed when upgrading.
-But nonetheless you have to consider some characteristics while upgrading.</strong></p>
+h3. Upgrading with default Alchemy user model
 
-The following sections will give you further information of the upgrade process in Alchemy CMS from a specific version to more current versions.
+h4. Update the dependencies
 
-h3. Upgrade to latest version
+In order to update the dependencies, the <code>Gemfile</code> needs to be changed first.
 
-This section assumes that your installed Alchemy App has version <strong>v2.7</strong>. The the latest version (<strong>v3.0</strong>)
-requires <strong>Rails 4</strong>.
-<p> Please have a look at the explicit instructions mentioned in the appropriate "chapter for the egde version":../edge/upgrading.html .</p>
+* The complete authentication part is extracted from the Alchemy core, so the <code>alchemy-devise</code> gem is necessary now.
 
-h3. Upgrade from prior version
+That part of your updated Gemfile should look like this:
 
-h4. Upgrade from version 2.6.x
-
-This section assumes that your installed Alchemy App has version <strong>v2.6</strong> and you like to upgrade to version <strong>v2.7</strong>.
-
-First of all you have to adopt your Gemfile:
-
-<pre>
+<ruby>
 ...
-gem 'alchemy_cms', :github => 'magiclabs/alchemy_cms', :branch => '2.7-stable'
+gem 'alchemy_cms', :github => 'magiclabs/alchemy_cms', :branch => '2.9-stable'
+gem 'alchemy-devise', :github => 'magiclabs/alchemy-devise', :branch => 'master'
 ...
-</pre>
+</ruby>
 
-Run in terminal:
+You should now update the dependencies via bundler.
 
 <shell>
-bundle update alchemy_cms
+bundle update
 </shell>
 
-to update Alchemy by using the recent version defined in the <code>Gemfile</code>.
+h4. Installing alchemy-devise migrations
 
-Finally, run the following command to finish the upgrade process:
+In order to update the user model, the migrations of the alchemy-devise gem need to be copied to the App.
 
 <shell>
-bundle exec rake alchemy:upgrade
+bundle exec rake alchemy_devise:install:migrations
 </shell>
 
-<br />
+h4. Run the Alchemy Upgrader
 
-h5. Additional information
-
-<strong>device-encryptable gem has been removed</strong>
-
-If you're updating a project from version < <strong>v2.5</strong>, please make sure to install <p>the gem <code>devise-encryptable</code>. Add to your Gemfile:</p>
-<pre>
-gem 'devise-encryptable'
-</pre>
-
-<br />
-
-h4. Upgrade from version 2.5 to 2.6
-
-This section assumes that your installed Alchemy App has version <strong>v2.5</strong> .
-
-<pre>
-...
-gem 'alchemy_cms', :github => 'magiclabs/alchemy_cms', :branch => '2.5-stable'
-...
-</pre>
-
-Run in terminal:
-
-<shell>
-bundle update alchemy_cms
-</shell>
-to update Alchemy by using the recent version defined in the <code>Gemfile</code>.
-
-Finally, run the following command to finish the upgrade process:
+Now you can run the upgrade task.
+While upgrading, you will get informations about the process on your screen.
 
 <shell>
 bundle exec rake alchemy:upgrade
 </shell>
 
-h5. Additional information
+h5. Remove the Devise module configuration
 
-<strong>nested URLs are activated by default</strong>
-
-Unless you intend to use nested URL (like <code>/portfolio/consulting</code>), you should disable
-URL Nesting via:
-
-<pre>
-# config/alchemy/config.yml
-url_nesting: false
-</pre>
-
-<br />
-
-h4. Upgrade from version 2.4 to 2.5
-
-This section assumes that your installed Alchemy App has version <strong>v2.4</strong> .
-
-<pre>
-...
-gem 'alchemy_cms', :github => 'magiclabs/alchemy_cms', :branch => '2.5-stable'
-...
-</pre>
-
-Run in terminal:
-
-<shell>
-bundle update alchemy_cms
-</shell>
-to update Alchemy by using the recent version defined in the <code>Gemfile</code>.
-
-Finally, run the following command to finish the upgrade process:
-
-<shell>
-bundle exec rake alchemy:upgrade
-</shell>
-
-h5. Additional information
-
-<strong>Authlogic has been replaced by Devise</strong>
-
-We changed the authentication provider from <code>Authlogic</code> to <code>Devise</code>.
-<p>Run (in terminal):</p>
-
-<shell>
-rails g alchemy:devise
-</shell>
-
-And alter the encryptor to <code>authlogic_sha512</code> and the stretches value from 10 to 20:
-
-<pre>
-# config/initializers/devise.rb
-...
-config.stretches = Rails.env.test? ? 1 : 20
-config.encryptor = :authlogic_sha512
-...
-</pre>
-
-Add the encryptable module to your <code>config.yml</code>
-
-<pre>
-# config/alchemy/config.yml
+<yaml>
+# === Devise modules
+#
+# List of Devise modules that should be activated on the user model.
+#
 devise_modules:
   - :database_authenticatable
   - :trackable
   - :validatable
   - :timeoutable
   - :recoverable
-  - :encryptable
-</pre>
+  # - :encryptable # Uncomment this if you are upgrading from an Alchemy version < 2.5.0
+</yaml>
 
-<strong>Translation via <code>t</code> method:</strong>
+h4. Adjust the user roles
 
-If you use the <code>t</code> method to translate alchemy scoped keys, then you have to use the <code>_t</code> method from now on.
-The method has been changed, in order to avoid conflicts with the <code>t</code> provided by Rails.
+The old role <code>registered</code> is now <code>member</code>
 
-<strong>Standard Set</strong>
+<yaml>
+user_roles: [member, author, editor, admin]
+</yaml>
 
-If your website is based on the <code>standard-set</code> of Alchemy, make sure to add the gem: <code>alchemy-demo_kit</code> to your
-Gemfile.
+h4. Add the regular expression for verifying email addresses
 
-<strong>EssencePicture uses figure and figcaption</strong>
+<yaml>
+email_regexp: !ruby/regexp '/\A[^@\s]+@([^@\s]+\.)+[^@\s]+\z/'
+</yaml>
 
-Since several Browser do not provide styles for these tags, you have to define them on you own.
 
-For example:
+h3. Upgrading to use custom user model
 
-<pre>
-figure {
-  margin: 0;
-}
-</pre>
+h4. Update the Gemfile
 
-<br />
+Adopt the url name to use the latest version
 
-h4. Upgrade from version 2.3 to 2.4
-
-This section assumes that your installed Alchemy App has version <strong>v2.3</strong> .
-
-<pre>
+<ruby>
 ...
-gem 'alchemy_cms', :github => 'magiclabs/alchemy_cms', :branch => '2.4-stable'
+gem 'alchemy_cms', :github => 'magiclabs/alchemy_cms', :branch => '2.9-stable'
 ...
-</pre>
+</ruby>
 
-Run in terminal:
+and update Alchemy:
 
 <shell>
 bundle update alchemy_cms
 </shell>
-to update Alchemy by using the recent version defined in the <code>Gemfile</code>.
 
-Finally, run the following command to finish the upgrade process:
+h4. Execute the  Alchemy Upgrader
 
-<shell>
-bundle exec rake alchemy:upgrade
-</shell>
-
-h5. Additional information
-
-<strong>Application Layout</strong>
-
-The layout file <code>pages.html.erb</code> has been removed.
-Therefore you just have to rename and move the file from <code>app/views/layouts/alchemy/pages.html.erb</code> <br />
-to <code>app/views/layouts/application.html.erb</code>.</p>
-
-<strong>DDOS protection while rendering images</strong>
-
-A new DDOS protection for images has been introduced in version <strong>v2.4</strong>.
-If you are already using <code>render_essence_view_*</code> helper, nothing has to be changed.
-Otherwise, e.g. in case of manually created URLs for images (by JS picture galleries, ...), the security token is required.
-
-If the code look like this (at the moment):
-
-<pre>
-<%= link_to alchemy.show_picture_path(:id => content.essence.picture.id, :name => content.essence.picture.urlname, :format => :png), :class => 'zoom', :title => content.essence.caption do %>
-  <%= render_essence_view(content, :image_size => "363x397") %>
-<% end %>
-</pre>
-
-it can be replaced by the following:
-
-<pre>
-<%= link_to show_alchemy_picture_path(content.essence.picture, :format => :png), :class => 'zoom', :title => content.essence.caption do %>
-  <%= render_essence_view(content, :image_size => "363x397") %>
-<% end %>
-</pre>
-
-Instead of using the <code>show_alchemy_picture_path</code> helper, you can get the security token with <code>security_token({image_size: '363x397'})</code> from the picture object. Subsequently assign the token to the key <code>sh:</code>.
-
-<strong>Richmedia Essences</strong>
-
-The richmedia essences (video, audio, flash) has been removed from the core and extracted into a seperate gem.
-If your project uses some of these essences, add the <code>alchemy-richmedia-essences</code> to your Gemfile.
-
-Usually, if your project does not contain the mentioned types of essences you can remove the correspond tables from the database.
-
-Run the commands:
-<shell>
-rails g migration remove_alchemy_richmedia_essences
-</shell>
-
-The migration file, may look like this:
-
-<pre>
-class RemoveAlchemyRichmediaEssences < ActiveRecord::Migration
-  def up
-    drop_table :alchemy_essence_audios
-    drop_table :alchemy_essence_flashes
-    drop_table :alchemy_essence_videos
-  end
-
-  def down
-    raise IrreversibleMigration
-  end
-end
-</pre>
-
-and finish migration:
-
-<shell>
-bundle exec rake db:migrate
-</shell>
-
-<strong>SSL obligation</strong>
-
-We strongly recommend you to enable the SSL option for the backend, supposing you've got an SSL certificate.
-
-<br />
-
-h4. Upgrade from version 2.2 to 2.3
-
-This section assumes that your installed Alchemy App has version <strong>v2.2</strong> .
-
-<pre>
-...
-gem 'alchemy_cms', :github => 'magiclabs/alchemy_cms', :branch => '2.3-stable'
-...
-</pre>
-
-Run in terminal:
-
-<shell>
-bundle update alchemy_cms
-</shell>
-to update Alchemy by using the recent version defined in the <code>Gemfile</code>.
-
-Finally, run the following command to finish the upgrade process:
+Now you can run the upgrade task.
+While upgrading, you will get informations about the process on your screen.
 
 <shell>
 bundle exec rake alchemy:upgrade
 </shell>
 
-h5. Additional information
+In order to tell Alchemy to use your own user model please follow the instructions in the chapter :
+"Custom authentication":custom_authentication.html .
 
-<strong>Update EssencePicture ressources</strong>
-
-Since version <strong>v2.3</strong> it is possible to use both <code>EssencePicture</code> and <strong>picture gallery</strong> in
-an element. As a result the database needs an update and you have to adopt the <code>elements.yml</code>.
-
-Add to <code>db/seeds.rb</code> in <code>module Alchemy</code> block:
-
-<pre>
-Element.named(["article", "bild"]).each do |element|
-  element.contents.essence_pictures.each do |content|
-    content.update_column(:name, "image")
-  end
-end
-
-Element.named(["gallery1", "gallery2"]).each do |element|
-  element.contents.essence_pictures.each_with_index do |content, i|
-    content.update_column(:name, "essence_picture_#{i+1}")
-  end
-end
-</pre>
-
-<strong>Important:</strong>
-* for each element that should contain a single picture, add the name of the element to the array in the first iteration
-* for each element that should contain a picture gallery, add the name of the element to the array in the second iteration
-
-INFO: If an element uses a different name than <code>"image"</code>, append an additional iteration exclusivly for this element.
-
-Update the database:
-
-<shell>bundle exec rake db:seed</shell>
-
-Now you can edit the <code>config/alchemy/elements.yml</code>:
-
-* <strong>for elements which should contain an single picture</strong>
-
-<pre>
-- name: article
-  contents:
-  - name: image
-    type: EssencePicture
-</pre>
-
-* <strong>for elements with a picture gallery</strong>
-
-<pre>
-- name: gallery
-  picture_gallery: true
-</pre>
-
-NOTE: The name of the <code>contents</code> attribute depends on the name you set in the <code>seeds.rb</code>.
-
-In the <strong>editor partials</strong> of the affected elements:
-
-Replace (in <code>app/views/elements/_element_name_editor.html.erb</code>):
-<pre>
-render_picture_editor(element, :maximum_amount_of_images => 1)
-</pre>
-
-by
-
-<pre>
-render_essence_editor_by_name(element, 'image')
-</pre>
-
-NOTE: The name of the essences may be different according to your choice in <code>db/seeds.rb</code>.
-
-Please ensure that <strong>the task <code>rake db:seed</code> will be executed on the server too</strong>.
-Therefore add this task to <code>deploy.rb</code>.
-
-<br />
-
-h4. Upgrade from  2.1 to version 2.2
-
-This section assumes that your installed Alchemy App has version <strong>v2.1</strong> .
-
-This Alchemy version uses <strong>Rails 3.2</strong>.
-Adopt your <code>Gemfile</code> in order to prepare for the update:
-
-<pre>
-source 'http://rubygems.org'
-
-gem 'rails', '~> 3.2.13'
-gem 'alchemy_cms', :github => 'magiclabs/alchemy_cms', :branch => '2.2-stable'
-gem 'mysql2'
-
-# Gems used only for assets and not required
-# in production environments by default.
-group :assets do
-  gem 'sass-rails', " ~> 3.2.3"
-  gem 'coffee-rails', " ~> 3.2.1"
-  gem 'uglifier', '>= 1.0.3'
-  gem 'quiet_assets'
-  gem 'turbo-sprockets-rails3'
-end
-
-group :development do
-  gem 'capistrano'
-  gem 'thin'
-end
-</pre>
-
-Run in terminal:
-
-<shell>
-bundle update rails alchemy_cms
-</shell>
-to initiate the update.
-Update rails with the following command:
-
-<shell>
-bundle exec rake rails:update
-</shell>
-
-During the upgrade task of rails, choose the option to overwrite all files, except <code>config/routes.rb</code>.
-Overwriting <code>config/enviroments/production.rb</code> should be <strong>handled with care</strong>.
-
-Custom stylesheets (CSS) have to be registered for precompilation.
-Now you should edit <code>config/application.rb</code> in order to match the <code>default_locale</code> and <code>time_zone</code>.
-
-Finally, run the following command to finish the upgrade process:
-
-<shell>
-bundle exec rake alchemy:upgrade
-</shell>
-
-h5. Additional information
-
-The navigation renderer received the class <code>navigation</code> and appends the level of the item as an additional class.
-
-The css selector before:
-
-<pre>
-ul.navigation_level_1
-</pre>
-
-and after
-
-<pre>
-ul.navigation.level_1
-</pre>
-
-The <strong>translation of the mailer</strong> has been moved to the scope of Alchemy.
-Consequently you might have to adopt your locale files (<code>config/locales</code>):
-
-If your locale file (.yml) look like this:
-
-<pre>
-alchemy:
-  contactform:
-    validations:
-      enter_mail: 'Please enter your email adress'
-      enter_name: 'Please entr your name'
-      enter_street: 'Please enter the name of the street'
-      enter_zipcode: 'Please enter your postal code'
-      enter_city: 'Please enter your enter_city'
-</pre>
-
-you can easily edit it to:
-
-<pre>
-activemodel:
-  errors:
-    models:
-      alchemy/message:
-        attributes:
-          lastname:
-            blank: '^Bitte geben Sie Ihren Namen an'
-          email:
-            blank: '^Bitte geben Sie Ihre E-Mail-Adresse an'
-          strasse:
-            blank: '^Bitte geben Sie Ihre Adresse an'
-          plz:
-            blank: '^Bitte geben Sie Ihre Postleitzahl an'
-          ort:
-            blank: '^Bitte geben Sie Ihren Ort an'
-</pre>
-
-<br />
-
-h3. F.A.Q.
-
-* <p><strong>GemNotFound</strong></p>
-If you encounter the error <code>GemNotFound: Could not find....</code>, please make sure that all required gems are installed. Run
-<shell>bundle install</shell>
-p((. to install missing gems.
-
-
-
-
-
-&nbsp;
+Finished, yay!


### PR DESCRIPTION
Based on guides for v2.7 with minor adoptions relating user model. 
Includes upgrade instructions
