### PR TITLE
Fix custom authentication link in getting started guide

### DIFF
--- a/source/getting_started.md
+++ b/source/getting_started.md
@@ -133,7 +133,7 @@ bundle exec rake alchemy:install\
 
 If you already have your own user class in your application, you have to
 tell Alchemy about it. Please follow [this
-guide](/custom_authentication.html) to learn how to achieve that.
+guide](custom_authentication.html) to learn how to achieve that.
 
 If you don’t have a authentication solution, you can use the
 alchemy-devise gem.


### PR DESCRIPTION
The custom authentication link will always link to http://guides.alchemy-cms.com/custom_authentication.html which results in a 404 error. 