### PR TITLE
typo in documentation

### DIFF
--- a/guides/source/cells.md
+++ b/guides/source/cells.md
@@ -36,7 +36,7 @@ INFO: You can only add elements that are both defined in your `cells.yml` and `p
 
 ~~~ yaml
 - name: standard
-  cells: left_column
+  cells: [left_column]
   elements: [image, text]
 ~~~
 


### PR DESCRIPTION
I see the same configuration in the demo site, without an Array it will fail