### PR TITLE
adjust rdoc link

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,7 +77,7 @@
           <p>
             <a href="http://alchemy-cms.com">Alchemy CMS Website</a><br>
             <a href="https://github.com/magiclabs/alchemy_cms">Sourcecode</a><br>
-            <a href="http://rdoc.info/github/magiclabs/alchemy_cms">API Documentation</a><br>
+            <a href="http://rdoc.info/github/AlchemyCMS/alchemy_cms">API Documentation</a><br>
             <a href="https://github.com/magiclabs/alchemy_cms/issues">Issues</a>
           </p>
         </div>


### PR DESCRIPTION
Fixes `[View on GitHub]` links on rubydoc.info.