### PR TITLE
change consumption to assumption, change model to essence_person from…

### DIFF
--- a/guides/source/create_essences.textile
+++ b/guides/source/create_essences.textile
@@ -28,7 +28,7 @@ class Alchemy::EssenceHeadline < ActiveRecord::Base
 end
 </ruby>
 
-Alchemy makes some consumptions about your essence. First of all it looks for a <code>body</code> column that it uses as <code>ingredient</code> column.
+Alchemy makes some assumptions about your essence. First of all it looks for a <code>body</code> column that it uses as <code>ingredient</code> column.
 
 If you want to store the value in another column, please use one of "the various options":http://rubydoc.info/github/AlchemyCMS/alchemy_cms/Alchemy/Essence/ClassMethods:acts_as_essence the <code>acts_as_essence</code> class method provides.
 
@@ -75,14 +75,14 @@ Just make shure that you provide form fields that Alchemy can use to update your
 
 h3. Associations
 
-You can associate every ActiveRecord based model with an essence. In this example we want to connect an existing <code>Product</code> model to an element, so we can associate it with an Alchemy page.
+You can associate every ActiveRecord based model with an essence. In this example we want to connect an existing <code>Person</code> model to an element, so we can associate it with an Alchemy page.
 
 Just use the ingredient_column option to tell Alchemy the foreign key to use for the association.
 
 h4. Set the foreign key
 
 <ruby>
-# app/models/alchemy/essence_product.rb
+# app/models/alchemy/essence_person.rb
 class Alchemy::EssencePerson < ActiveRecord::Base
   acts_as_essence ingredient_column: 'person_id'
 end


### PR DESCRIPTION
Fixes English word usage error, changing **make some consumptions** to **make some assumptions**

Fixes error in example, changing file to ```essence_person.rb``` from ```essence_product.rb```

Change to **connect an existing Person model**  from **connect an existing Product model**

I believe these changes are first step to making Guide a bit more lucid for this example.
For some reason the Guide retrograded from example in 2.7, which I believe was much 
more useful.  If there is some consensus on this, I would propose reinstating some of that 
example along with expanding the current example to give  a better picture of what is going on,
and additional hint on what to do / what can be done.