### PR TITLE
Update best_practice_create_form.md

### DIFF
--- a/guides/source/best_practice_create_form.md
+++ b/guides/source/best_practice_create_form.md
@@ -20,7 +20,7 @@ mailer:
   mail_success_page: thanks
   mail_from: your.mail@your-domain.com
   mail_to: your.mail@your-domain.com
-  fields: [salutation, firstname, lastname, address, zip, city, phone, email, message]
+  fields: [salutation, firstname, lastname, address, zip, city, phone, email, message, contact_form_id]
   validate_fields: [lastname, email]
 ~~~
 


### PR DESCRIPTION
When using Alchemy versions that use strong parameters, the `contact_form_id` needs to be added to the field list.