### PR TITLE
Remove `redirects_to_external` documentation.

### DIFF
--- a/guides/pages.md
+++ b/guides/pages.md
@@ -67,10 +67,6 @@ Every page layout needs at least a name. You don't need to set every option. It 
 
   Pass `true` to enable a RSS feed of news elements from this page.
 
-* **redirects_to_external** `Boolean` (Default `false`)
-
-  Pass `true` to disable normal page rendering and redirect to a external page instead.
-
 * **controller** `String`
 
   Controller to use instead of the default `Alchemy::PagesController`


### PR DESCRIPTION
I just stumbled across this today looking for the feature, then wondered why it does not work :grinning: 

If I understand it correctly, the feature has been removed here: https://github.com/AlchemyCMS/alchemy_cms/pull/1686

So this tiny change should bring the (otherwise excellent!) docs up-to-date.