### PR TITLE
Fix possible typo

### DIFF
--- a/guides/ingredients.md
+++ b/guides/ingredients.md
@@ -286,7 +286,7 @@ Note how `element_view_for` allows you to call `el.render` on ingredients within
 
 Without using the `element_view_for` helper, you can still access ingredients:
 
-`article.ingredient_by_name('headline')&.value`
+`article.ingredient_by_role('headline')&.value`
 
 But the `el.render` helper takes care of generating the appropriate DOM elements to display the ingredient based on its type. It is recommended you rely on these helpers unless you are comfortable with the structure of the ingredient model you are trying to render.
 


### PR DESCRIPTION
Not having used alchemy in some time, I had to check the docs and stumbled across the mention of the method `ingredient_by_name`. As far as I can tell this method does not exist. `ingredient_by_role` seems to be what most people would want here I guess.

Feel free to ignore if my guess is wrong. And as always, keep up the good work!