### PR TITLE
Fix link to How To Create Custom Ingredients

### DIFF
--- a/guides/ingredients.md
+++ b/guides/ingredients.md
@@ -13,7 +13,7 @@ Alchemy uses Rails [Single Table Inheritance](https://guides.rubyonrails.org/ass
 
 Alchemy comes with a lot of predefined ingredients for the regular needs of a website project. Combine them like a chemestry kit into [elements](elements).
 
-Ingredients are Rails models. It is pretty easy to [add your own ingredient class](custom_ingredients) as well.
+Ingredients are Rails models. It is pretty easy to [add your own ingredient class](how_to_create_custom_ingredients) as well.
 
 ## Definition
 
@@ -208,7 +208,7 @@ Useful for letting your user select from a limited set of choices.
 ~~~
 
 ::: tip
-If you need dynamic values (ie, a from a product catalogue), please [create a custom ingredient class](custom_ingredients) that provides the values.
+If you need dynamic values (ie, a from a product catalogue), please [create a custom ingredient class](how_to_create_custom_ingredients) that provides the values.
 :::
 
 ## Link


### PR DESCRIPTION
This updates the article link since it was renamed.

Also, I noticed the redirect isn't working because the link seems to lose the mime type .html