### PR TITLE
Add redirect for elements page

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,7 @@
 [build]
   command = "./build.sh"
   publish = "guides/.vitepress/dist"
+[[redirects]]
+  from = "/stable/elements.html"
+  to = "/elements.html"
+  status = 301


### PR DESCRIPTION
/stable/elements.html isn't reachable anymore but
was used in the alchemy template for elements.yml.tt

Redirects now to /elements.html