### PR TITLE
Document multiple selection option for Select ingredient

### DIFF
--- a/guides/ingredients.md
+++ b/guides/ingredients.md
@@ -225,7 +225,7 @@ Stores a `Boolean` value in the database. Renders a checkbox in the editor parti
 
 ## Select
 
-Renders a select box in the editor partial and stores the value as `String`.
+Renders a select box in the editor partial and stores the value as `String`. When configured for multiple selection, it stores the values as an `Array`.
 
 Useful for letting your user select from a limited set of choices.
 
@@ -235,13 +235,29 @@ Useful for letting your user select from a limited set of choices.
 
   A list of values your users can select from. Use [a two dimensional array](https://guides.rubyonrails.org/form_helpers.html#the-select-and-option-tags) for having value and text pairs.
 
+* **multiple** `Boolean` (default: false)
+
+  If set to `true`, the user can select multiple values from the list. The selected values will be stored as an `Array` instead of a single `String`.
+
 ### Example
+
+Single selection (default):
 
 ~~~ yaml
 - name: width
   type: Select
   settings:
     select_values: ['200', '300', '400']
+~~~
+
+Multiple selection:
+
+~~~ yaml
+- name: categories
+  type: Select
+  settings:
+    select_values: ['Technology', 'Design', 'Marketing', 'Sales']
+    multiple: true
 ~~~
 
 ::: tip

--- a/guides/ingredients.md
+++ b/guides/ingredients.md
@@ -239,6 +239,10 @@ Useful for letting your user select from a limited set of choices.
 
   If set to `true`, the user can select multiple values from the list. The selected values will be stored as an `Array` instead of a single `String`.
 
+* **default** `String` (optional)
+
+  A default value to prefill newly created elements. The value must be one of the values from `select_values`.
+
 ### Example
 
 Single selection (default):
@@ -248,6 +252,7 @@ Single selection (default):
   type: Select
   settings:
     select_values: ['200', '300', '400']
+  default: '300'
 ~~~
 
 Multiple selection:


### PR DESCRIPTION
## Summary

  Adds documentation for the new `multiple` setting on the Select ingredient that enables multiple value selection.

  ## Changes

  - Updated Select ingredient description to explain Array storage for multiple selections
  - Added `multiple: true` setting documentation with default value
  - Added two examples: single selection (default) and multiple selection
  - Clarified that values are stored as `String` by default and as `Array` when multiple is enabled

  ## Example Usage

  ```yaml
  - name: categories
    type: Select
    settings:
      select_values: ['Technology', 'Design', 'Marketing', 'Sales']
      multiple: true
```