### PR TITLE
Docs: correct the link_target_options description

### DIFF
--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -125,7 +125,9 @@ end
 ### link_target_options
 `Array<String>` (Default: `["blank"]`)
 
-Values for the link target select in the link dialog. The value is added as a `data-link-target` attribute.
+Values for the link target select in the link dialog. Each value is stored with a leading underscore and rendered as the link's `target` attribute, so `blank` becomes `target="_blank"`.
+
+If you render a link ingredient in your own view, pass the stored value through `Alchemy::Ingredients::LinkTarget#link_target_value` instead of comparing it yourself. It also maps the legacy `blank` value, stored before the underscore was added.
 
 ### link_dialog_tabs
 


### PR DESCRIPTION
Hey 👋 First time contributing here — we recently migrated a site over to
Alchemy, and this one sentence sent us down a small rabbit hole.

First of all, thank you for writing and maintaining these guides next to the CMS
itself, and for giving all of it away for free. They were our main companion
through the whole rebuild, and documentation work rarely gets the thanks it
deserves. 🙏

The `link_target_options` description says the configured value "is added as a
`data-link-target` attribute". That is pre-8.0 behavior.

These days `Alchemy::Page.link_target_options` prepends an underscore to every
configured value ("add an underscore to the options to provide the default
syntax"), so the link dialog stores `_blank` — not `blank` — and the ingredient
views render it as the link's `target` attribute
(`Alchemy::Ingredients::LinkTarget`). `data-link-target` only survives as a
marker attribute on the hidden field inside the ingredient editor.

This page is the only place documenting the setting, so it is what you read
before rendering a link ingredient in your own view. Following the old
description, you compare the stored value against the bare `blank` and quietly
drop the setting for every link an editor sets — a missing `target` looks exactly
like "same window". 🙈 That is how we found it, while a 1:1 content migration
wrote the ingredients directly.

So this corrects the sentence and adds a pointer to
`Alchemy::Ingredients::LinkTarget#link_target_value`, which also maps the legacy
value. Happy to reword it if you would put it differently — and thanks in advance
for taking the time to look. 🙂

Companion PR in the gem, correcting the same description in the configuration
class, the installer template and `config/alchemy/config.yml`:
AlchemyCMS/alchemy_cms#4097
