### PR TITLE
docs(richtext): Correct HTML sanitization behavior

### DIFF
--- a/guides/how_to_customize_tinymce.md
+++ b/guides/how_to_customize_tinymce.md
@@ -158,9 +158,9 @@ Alchemy automatically switches between a light (`alchemy`) and dark (`alchemy-da
 
 ## HTML Sanitization
 
-Alchemy sanitizes richtext content before saving using Rails' [SafeListSanitizer](https://api.rubyonrails.org/classes/Rails/HTML/SafeListSanitizer.html). By default, Rails allows a generous set of tags (`p`, `strong`, `em`, `a`, `ul`, `ol`, `li`, `h1`-`h6`, `blockquote`, `br`, `img`, `span`, and more).
+A Richtext ingredient is a trusted-content field: by default its value is rendered as-is, so whatever markup is saved ends up unescaped in the page.
 
-To be more restrictive, configure which tags and attributes are allowed per ingredient:
+To restrict what gets rendered, configure a `sanitizer:` setting on the ingredient. When it is present, Alchemy sanitizes the value at render time with Rails' [SafeListSanitizer](https://github.com/rails/rails-html-sanitizer#safelistsanitizer), keeping only the tags and attributes you list:
 
 ~~~ yaml
 - name: text
@@ -182,6 +182,11 @@ To be more restrictive, configure which tags and attributes are allowed per ingr
         - target
         - class
 ~~~
+
+::: warning
+Without a `sanitizer:` setting the value is rendered unescaped. Configure a `sanitizer:` on every Richtext ingredient and allow only the tags and attributes that element actually needs.
+:::
+
 ## Configuration Syntax
 
 Any [TinyMCE configuration option](https://www.tiny.cloud/docs/tinymce/latest/editor-important-options/) can be used. When setting options in Ruby (initializer), convert JavaScript syntax to Ruby hashes:

--- a/guides/ingredients.md
+++ b/guides/ingredients.md
@@ -163,6 +163,11 @@ See the [TinyMCE customization guide](how_to_customize_tinymce#per-ingredient-cu
 
 Customize the TinyMCE editor for this ingredient.
 
+#### sanitizer
+`Hash`
+
+Restrict which HTML tags and attributes the rendered value may contain. When set, the value is sanitized at render time; without it the value is rendered as-is. Accepts `tags` and `attributes` arrays. See the [TinyMCE customization guide](how_to_customize_tinymce#html-sanitization) for details.
+
 ## Picture
 
 Stores a reference to a picture from the Alchemy library.


### PR DESCRIPTION
The "HTML Sanitization" section of the TinyMCE customization guide described sanitization as a before-save pass with a generous default allow-list, which reads as if richtext output is filtered by default. That is misleading: a richtext value is rendered as-is unless a `sanitizer:` setting is configured, and when it is, the value is sanitized at render time (per alchemy_cms#4091), not from a stored before-save copy.

This rewrites the section to describe the actual render-time behavior, notes that a setting change takes effect without re-saving, and adds a warning that unconfigured richtext renders unescaped — so a reader does not mistake the default for a sanitized one when lower-trust users can edit richtext content.